### PR TITLE
dev_impove

### DIFF
--- a/DotNet/WPF/Src/Samples/App.xaml
+++ b/DotNet/WPF/Src/Samples/App.xaml
@@ -29,19 +29,6 @@
                         </pu:MessageBoxXSettings.ButtonStyle>
                     </pu:MessageBoxXSettings>
 
-                    <pu:NoticeBoxSettings x:Key="noticeSetting">
-                        <pu:NoticeBoxSettings.NoticeBoxItemStyle>
-                            <Style TargetType="pu:NoticeBoxItem"
-                                   BasedOn="{StaticResource {ComponentResourceKey ResourceId=NoticeBoxItemStyle, TypeInTargetAssembly={x:Type pu:NoticeBox}}}">
-                                <Setter Property="Background"
-                                        Value="#1E1E1E" />
-                                <Setter Property="BorderBrush"
-                                        Value="#4E4E4E" />
-                                <Setter Property="Foreground"
-                                        Value="White" />
-                            </Style>
-                        </pu:NoticeBoxSettings.NoticeBoxItemStyle>
-                    </pu:NoticeBoxSettings>
 
                 </ResourceDictionary>
                 <ResourceDictionary Source="pack://application:,,,/Panuon.UI.Silver;component/Control.xaml" />

--- a/DotNet/WPF/Src/Samples/Views/Examples/SignInView.xaml
+++ b/DotNet/WPF/Src/Samples/Views/Examples/SignInView.xaml
@@ -77,7 +77,7 @@
                 <Trigger Property="pu:ButtonHelper.IsPending"
                          Value="True">
                     <Setter Property="pu:ButtonHelper.ClickEffect"
-                            Value="Sink" />
+                            Value="Shake" />
                     <Setter Property="ContentTemplate">
                         <Setter.Value>
                             <DataTemplate>

--- a/DotNet/WPF/Src/SharedResources/Panuon.UI.Silver.Internal/Styles/PasswordBoxStyle.xaml
+++ b/DotNet/WPF/Src/SharedResources/Panuon.UI.Silver.Internal/Styles/PasswordBoxStyle.xaml
@@ -32,7 +32,37 @@
         <Setter Property="Foreground"
                 Value="{Binding Foreground, RelativeSource={RelativeSource AncestorType=PasswordBox}, Mode=OneWay}" />
     </Style>
-        
+
+    <Style x:Key="{ComponentResourceKey ResourceId=PlainButtonStyle, TypeInTargetAssembly={x:Type local:PasswordBoxHelper}}"
+           TargetType="Button"
+           BasedOn="{StaticResource {x:Static rs:StyleKeys.ButtonStyle}}">
+        <Setter Property="local:ButtonHelper.HoverForeground"
+                Value="{Binding Foreground, Converter={StaticResource {x:Static irs:ConverterKeys.LightenSolidColorBrushConverter}}, ConverterParameter=0.6, RelativeSource={RelativeSource Self}, Mode=OneWay}" />
+        <Setter Property="Background"
+                Value="Transparent" />
+        <Setter Property="local:ButtonHelper.HoverBackground"
+                Value="{x:Null}" />
+        <Setter Property="local:ButtonHelper.ClickBackground"
+                Value="{x:Null}" />
+        <Setter Property="FontFamily"
+                Value="/Panuon.UI.Silver;component/Resources/Fonts/#PanuonIcon" />
+        <Setter Property="FontSize"
+                Value="{Binding FontSize, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+        <Setter Property="Margin"
+                Value="0,0,5,0" />
+        <Setter Property="Content"
+                Value="&#xe94b;" />
+        <Setter Property="Foreground"
+                Value="{Binding Foreground, RelativeSource={RelativeSource AncestorType=PasswordBox}, Mode=OneWay}" />
+        <Style.Triggers>
+            <Trigger Property="IsPressed"
+                     Value="True">
+                <Setter Property="Content"
+                        Value="&#xe94c;" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <Style x:Key="{x:Static rs:StyleKeys.PasswordBoxStyle}"
            TargetType="PasswordBox">
         <Setter Property="i:VisualStateHelper.Regist"
@@ -59,6 +89,8 @@
                 Value="{Binding Path=(i:VisualStateHelper.Foreground), Converter={StaticResource {x:Static irs:ConverterKeys.BrushOpacityConverter}}, ConverterParameter=0.8, RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="local:PasswordBoxHelper.ClearButtonStyle"
                 Value="{StaticResource {ComponentResourceKey ResourceId=ClearButtonStyle, TypeInTargetAssembly={x:Type local:PasswordBoxHelper}}}" />
+        <Setter Property="local:PasswordBoxHelper.PlainButtonStyle"
+                Value="{StaticResource {ComponentResourceKey ResourceId=PlainButtonStyle, TypeInTargetAssembly={x:Type local:PasswordBoxHelper}}}" />
         <Setter Property="VerticalContentAlignment"
                 Value="Center" />
         <Setter Property="HorizontalContentAlignment"

--- a/DotNet/WPF/Src/SharedResources/Panuon.UI.Silver.Internal/Templates/PasswordBoxTemplate.xaml
+++ b/DotNet/WPF/Src/SharedResources/Panuon.UI.Silver.Internal/Templates/PasswordBoxTemplate.xaml
@@ -24,8 +24,10 @@
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition />
                     <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <TextBlock IsHitTestVisible="False"
+                           Focusable="False"
                            Margin="{TemplateBinding Padding}"
                            Padding="2,0,0,0"
                            Visibility="{Binding Path=(local:PasswordBoxHelper.Password), Converter={StaticResource {x:Static rs:ConverterKeys.StringNonnullAndNotEmptyToCollapseConverter}},RelativeSource={RelativeSource TemplatedParent},Mode=OneWay}"
@@ -33,7 +35,16 @@
                            Foreground="{Binding Path=(local:PasswordBoxHelper.WatermarkBrush),RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                <TextBlock IsHitTestVisible="False"
+                           Focusable="False"
+                           Margin="{TemplateBinding Padding}"
+                           Padding="2,0,0,0"
+                           Visibility="{Binding IsPressed, Converter={StaticResource {x:Static rs:ConverterKeys.FalseToHiddenConverter}}, ElementName=BtnPlain, Mode=OneWay}"
+                           Text="{Binding Path=(local:PasswordBoxHelper.Password),RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />
                 <ScrollViewer x:Name="PART_ContentHost"
+                              Visibility="{Binding IsPressed, Converter={StaticResource {x:Static rs:ConverterKeys.TrueToHiddenConverter}}, ElementName=BtnPlain, Mode=OneWay}"
                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
                 <Button x:Name="BtnClear"
@@ -42,6 +53,10 @@
                         Style="{Binding Path=(local:PasswordBoxHelper.ClearButtonStyle), RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                         Command="{Binding Path=(local:PasswordBoxHelper.ClearCommand), RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                         CommandParameter="{Binding RelativeSource={RelativeSource TemplatedParent}}" />
+                <Button x:Name="BtnPlain"
+                        Grid.Column="2"
+                        Visibility="Collapsed"
+                        Style="{Binding Path=(local:PasswordBoxHelper.PlainButtonStyle), RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
             </Grid>
         </i:ContentControlX>
         <ControlTemplate.Triggers>
@@ -107,6 +122,71 @@
                                Value="True" />
                 </MultiDataTrigger.Conditions>
                 <Setter TargetName="BtnClear"
+                        Property="Visibility"
+                        Value="Visible" />
+            </MultiDataTrigger>
+            <Trigger  Property="local:PasswordBoxHelper.PlainButtonVisibility"
+                      Value="Visible">
+                <Setter TargetName="BtnPlain"
+                        Property="Visibility"
+                        Value="Visible" />
+            </Trigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(local:PasswordBoxHelper.PlainButtonVisibility), RelativeSource={RelativeSource Self}, Mode=OneWay}"
+                               Value="VisibleOnNonnull" />
+                    <Condition Binding="{Binding Path=(local:PasswordBoxHelper.Password), Converter={StaticResource {x:Static rs:ConverterKeys.IsStringNonnullAndNotEmptyConverter}}, RelativeSource={RelativeSource Self}, Mode=OneWay}"
+                               Value="True" />
+                </MultiDataTrigger.Conditions>
+                <Setter TargetName="BtnPlain"
+                        Property="Visibility"
+                        Value="Visible" />
+            </MultiDataTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="local:PasswordBoxHelper.PlainButtonVisibility"
+                               Value="VisibleOnHover" />
+                    <Condition Property="IsMouseOver"
+                               Value="True" />
+                </MultiTrigger.Conditions>
+                <Setter TargetName="BtnPlain"
+                        Property="Visibility"
+                        Value="Visible" />
+            </MultiTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(local:PasswordBoxHelper.PlainButtonVisibility), RelativeSource={RelativeSource Self}, Mode=OneWay}"
+                               Value="VisibleOnHoverAndNonnull" />
+                    <Condition Binding="{Binding Path=(local:PasswordBoxHelper.Password), Converter={StaticResource {x:Static rs:ConverterKeys.IsStringNonnullAndNotEmptyConverter}}, RelativeSource={RelativeSource Self}, Mode=OneWay}"
+                               Value="True" />
+                    <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource Self}, Mode=OneWay}"
+                               Value="True" />
+                </MultiDataTrigger.Conditions>
+                <Setter TargetName="BtnPlain"
+                        Property="Visibility"
+                        Value="Visible" />
+            </MultiDataTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="local:PasswordBoxHelper.PlainButtonVisibility"
+                               Value="VisibleOnFocused" />
+                    <Condition Property="IsKeyboardFocusWithin"
+                               Value="True" />
+                </MultiTrigger.Conditions>
+                <Setter TargetName="BtnPlain"
+                        Property="Visibility"
+                        Value="Visible" />
+            </MultiTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(local:PasswordBoxHelper.PlainButtonVisibility), RelativeSource={RelativeSource Self}, Mode=OneWay}"
+                               Value="VisibleOnFocusedAndNonnull" />
+                    <Condition Binding="{Binding Path=(local:PasswordBoxHelper.Password), Converter={StaticResource {x:Static rs:ConverterKeys.IsStringNonnullAndNotEmptyConverter}}, RelativeSource={RelativeSource Self}, Mode=OneWay}"
+                               Value="True" />
+                    <Condition Binding="{Binding IsKeyboardFocusWithin, RelativeSource={RelativeSource Self}, Mode=OneWay}"
+                               Value="True" />
+                </MultiDataTrigger.Conditions>
+                <Setter TargetName="BtnPlain"
                         Property="Visibility"
                         Value="Visible" />
             </MultiDataTrigger>

--- a/DotNet/WPF/Src/SharedResources/Panuon.UI.Silver/Helpers/PasswordBoxHelper.cs
+++ b/DotNet/WPF/Src/SharedResources/Panuon.UI.Silver/Helpers/PasswordBoxHelper.cs
@@ -264,6 +264,36 @@ namespace Panuon.UI.Silver
             DependencyProperty.RegisterAttached("ClearButtonStyle", typeof(Style), typeof(PasswordBoxHelper));
         #endregion
 
+        #region PlainButtonVisibility
+        public static AuxiliaryButtonVisibility GetPlainButtonVisibility(PasswordBox passwordBox)
+        {
+            return (AuxiliaryButtonVisibility)passwordBox.GetValue(PlainButtonVisibilityProperty);
+        }
+
+        public static void SetPlainButtonVisibility(PasswordBox passwordBox, AuxiliaryButtonVisibility value)
+        {
+            passwordBox.SetValue(PlainButtonVisibilityProperty, value);
+        }
+
+        public static readonly DependencyProperty PlainButtonVisibilityProperty =
+            DependencyProperty.RegisterAttached("PlainButtonVisibility", typeof(AuxiliaryButtonVisibility), typeof(PasswordBoxHelper));
+        #endregion
+
+        #region PlainButtonStyle
+        public static Style GetPlainButtonStyle(PasswordBox passwordBox)
+        {
+            return (Style)passwordBox.GetValue(PlainButtonStyleProperty);
+        }
+
+        public static void SetPlainButtonStyle(PasswordBox passwordBox, Style value)
+        {
+            passwordBox.SetValue(PlainButtonStyleProperty, value);
+        }
+
+        public static readonly DependencyProperty PlainButtonStyleProperty =
+            DependencyProperty.RegisterAttached("PlainButtonStyle", typeof(Style), typeof(PasswordBoxHelper));
+        #endregion
+
         #endregion
 
         #region Commands

--- a/DotNet/WPF/Src/SharedResources/Panuon.UI.Silver/Helpers/TextBlockHelper.cs
+++ b/DotNet/WPF/Src/SharedResources/Panuon.UI.Silver/Helpers/TextBlockHelper.cs
@@ -37,7 +37,7 @@ namespace Panuon.UI.Silver
         }
 
         public static readonly DependencyProperty HighlightRuleProperty =
-            DependencyProperty.RegisterAttached("HighlightRule", typeof(HighlightRule), typeof(TextBlockHelper), new PropertyMetadata(HighlightRule.All));
+            DependencyProperty.RegisterAttached("HighlightRule", typeof(HighlightRule), typeof(TextBlockHelper), new PropertyMetadata(HighlightRule.All, OnHighlightTextChanged));
         #endregion
 
         #region HighlightForeground
@@ -52,7 +52,7 @@ namespace Panuon.UI.Silver
         }
 
         public static readonly DependencyProperty HighlightForegroundProperty =
-            DependencyProperty.RegisterAttached("HighlightForeground", typeof(Brush), typeof(TextBlockHelper), new PropertyMetadata(Brushes.Red));
+            DependencyProperty.RegisterAttached("HighlightForeground", typeof(Brush), typeof(TextBlockHelper), new PropertyMetadata(Brushes.Red, OnHighlightTextChanged));
         #endregion
 
         #region HighlightBackground
@@ -67,7 +67,7 @@ namespace Panuon.UI.Silver
         }
 
         public static readonly DependencyProperty HighlightBackgroundProperty =
-            DependencyProperty.RegisterAttached("HighlightBackground", typeof(Brush), typeof(TextBlockHelper), new PropertyMetadata(null));
+            DependencyProperty.RegisterAttached("HighlightBackground", typeof(Brush), typeof(TextBlockHelper), new PropertyMetadata(null, OnHighlightTextChanged));
 
         #endregion
 


### PR DESCRIPTION
- New Properties:
  PasswordBoxHelper.PlainButtonStyle
  PasswordBoxHelper.PlainButtonVisibility
  
- Fixup: 
	NoticeBox might throw an exception when calling from another thread.
	TextBlockHelper will not update highlights when properties are changed.